### PR TITLE
Revised canDelete inheritance

### DIFF
--- a/src/MenuSet.php
+++ b/src/MenuSet.php
@@ -108,20 +108,22 @@ class MenuSet extends DataObject implements PermissionProvider
      */
     public function canDelete($member = null)
     {
+        $canDelete = parent::canDelete($member);
+
         // Backwards compatibility for duplicate default sets
         $existing = MenuManagerTemplateProvider::MenuSet($this->Name);
         $isDuplicate = $existing && $existing->ID !== $this->ID;
 
         if ($this->isDefaultSet() && !$isDuplicate) {
             // Default menu's cannot be deleted
-            return false;
+            $canDelete = false;
         }
 
-        if (Permission::check('MANAGE_MENU_SETS')) {
-            return true;
+        if ($canDelete !== null) {
+            return $canDelete;
         }
 
-        return parent::canDelete($member);
+        return Permission::check('MANAGE_MENU_SETS');
     }
 
     /**


### PR DESCRIPTION
This change is currently on the `pulls/42` branch (https://github.com/StephenMakrogianni/silverstripe-menumanager/commits/pulls/42), but because we're consolidating multiple PR branches into this fork's `master` branch, this PR is to bring `master` up to date with the `pulls/42` branch