### PR TITLE
BUGFIX: PageID check on custom __get method

### DIFF
--- a/src/MenuItem.php
+++ b/src/MenuItem.php
@@ -174,8 +174,8 @@ class MenuItem extends DataObject implements PermissionProvider
         } else {
             $page = $this->Page();
 
-            if ($page instanceof DataObject) {
-                if ($page->ID != 0 && $page->hasMethod($field)) {
+            if ($page->ID != 0 && $page instanceof DataObject) {
+                if ($page->hasMethod($field)) {
                     return $page->$field();
                 } else {
                     return $page->$field;

--- a/src/MenuItem.php
+++ b/src/MenuItem.php
@@ -126,7 +126,8 @@ class MenuItem extends DataObject implements PermissionProvider
     {
         $fields = FieldList::create(TabSet::create('Root'));
 
-        $fields->addFieldsToTab('Root.main',
+        $fields->addFieldsToTab(
+            'Root.main',
             [
                 TextField::create('MenuTitle', 'Link Label')
                     ->setDescription('If left blank, will default to the selected page\'s name.'),
@@ -139,7 +140,8 @@ class MenuItem extends DataObject implements PermissionProvider
                 TextField::create('Link', 'URL')
                     ->setDescription('Enter a full URL to link to another website.'),
                 CheckboxField::create('IsNewWindow', 'Open in a new window?')
-            ]);
+            ]
+        );
 
         $this->extend('updateCMSFields', $fields);
 
@@ -173,7 +175,7 @@ class MenuItem extends DataObject implements PermissionProvider
             $page = $this->Page();
 
             if ($page instanceof DataObject) {
-                if ($page->hasMethod($field)) {
+                if ($page->ID != 0 && $page->hasMethod($field)) {
                     return $page->$field();
                 } else {
                     return $page->$field;


### PR DESCRIPTION
Issue: 
The custom `__get` method on `MenuItem` fails to check if the `$page` has a valid record, therefore in the event that it doesn't it defaults to Fluent's `Link()` method and pre populates the `Link` field with:
![image](https://user-images.githubusercontent.com/27745093/99302787-b755a600-28b4-11eb-87d1-09f0b5b0af28.png)

Fix:
Adds a check on `$page` to ensure it is a valid record before referencing its fields